### PR TITLE
Response(status=201, json_body=car.to_dict())

### DIFF
--- a/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/api/auto_api.py
+++ b/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/api/auto_api.py
@@ -45,7 +45,7 @@ def create_auto(request: Request):
 
     try:
         car = Repository.add_car(car)
-        return Response(status=201, json_body=car)
+        return Response(status=201, json_body=car.to_dict())
     except:
         return Response(status=400, body='Could not save car.')
 


### PR DESCRIPTION
Should it be car.to_dict()? Otherwise, exception will be thrown at the line 48. 
`Object of type 'Car' is not JSON serializable`