### PR TITLE
Keep the API behavior consistent 

### DIFF
--- a/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/data/repository.py
+++ b/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/data/repository.py
@@ -24,7 +24,8 @@ class Repository:
 
     @classmethod
     def all_cars(cls, limit=None):
-        cls.__load_data()
+        if not cls.__car_data:
+            cls.__load_data()
 
         cars = list(cls.__car_data.values())
         if limit:
@@ -67,6 +68,8 @@ class Repository:
 
     @classmethod
     def add_car(cls, car):
+        if not cls.__car_data:
+            cls.__load_data()
         key = Repository.generate_id()
         car.id = key
         cls.__car_data[key] = car

--- a/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/data/repository.py
+++ b/src/nearly_restful/04_svc2_restful_auto_service/restful_auto_service/data/repository.py
@@ -24,8 +24,7 @@ class Repository:
 
     @classmethod
     def all_cars(cls, limit=None):
-        if not cls.__car_data:
-            cls.__load_data()
+        cls.__load_data()
 
         cars = list(cls.__car_data.values())
         if limit:
@@ -68,8 +67,7 @@ class Repository:
 
     @classmethod
     def add_car(cls, car):
-        if not cls.__car_data:
-            cls.__load_data()
+        cls.__load_data()
         key = Repository.generate_id()
         car.id = key
         cls.__car_data[key] = car


### PR DESCRIPTION
Hi Mike, 
I have added a couple of lines to keep the Repository constant in two conditions: 
1. Multiple runs of GET all autos(). 
If the content keeps the same, it would be easier for those who are playing with the API code to track the changes. The current behavior is that when all_cars() is called it's reloading the dict with new uuids. 
2. Keep the API behavior the same in responding to different sequence of requests. 
In your video, you always get the list of all cars before you try out any other requests. However, what if someone is tweaking the code, restarts the server, adds a new car before listing all cars? When I was using postman testing the code, it happened to me and I was quite surprised to see there's only one car returned from the API. The sequence of the request will cause the API to behave differently. 

I know this code is just for demo purpose. But the experience might be smoother if the the API behaves consistently when someone is playing with the code. What do you think?