### PR TITLE
Fixing bug (line_data contains integers)

### DIFF
--- a/src/logging/02_final_logging_data_auto_service/restful_auto_service/renderers/csv_renderer.py
+++ b/src/logging/02_final_logging_data_auto_service/restful_auto_service/renderers/csv_renderer.py
@@ -32,7 +32,7 @@ class CSVRendererFactory(RendererAbstractBase):
         for row in value:
             line_data = []
             for k in headers:
-                line_data.append(row[k])
+                line_data.append(str(row[k]))
             line = ','.join(line_data)
             response_rows.append(line)
 


### PR DESCRIPTION
Since price and year in Car is defined as [sqlalchemy.Integer](https://github.com/mikeckennedy/restful-services-in-pyramid/blob/master/src/logging/02_final_logging_data_auto_service/restful_auto_service/data/car.py#L19), `,'.join(line_data)` will break.